### PR TITLE
Reset query state after the selected value get an invalid value

### DIFF
--- a/hbui/components/combobox/index.js
+++ b/hbui/components/combobox/index.js
@@ -1,11 +1,19 @@
 /* eslint no-unused-vars: [ "off", { "argsIgnorePattern": "tw" } ] */
 import tw from 'twin.macro'
-import React, { useState } from 'react'
+import React, { useState , useEffect } from 'react'
 import { Combobox } from '@headlessui/react'
 import { CheckIcon, XIcon, SelectorIcon } from '@heroicons/react/solid'
 
 export default function ComboBox({items, selected, setSelected, placeholderName, ...props}) {
   const [query, setQuery] = useState('')
+
+  // reset to empty query when selected is no longer valid value 
+  useEffect(()=>{
+    if (!selected){
+      setQuery('')
+    }
+  },[selected])
+
   const filteredItems =
     query === ''
       ? items


### PR DESCRIPTION
This is the PR to fix the issue when the external state gets reset to an invalid value, the dropdown suggestion that only appears to be one option only.