### PR TITLE
Add state props for menu dropdown

### DIFF
--- a/hbui/components/menudropdown/index.js
+++ b/hbui/components/menudropdown/index.js
@@ -13,7 +13,7 @@ function MenuDropdown({links, linkClass, side='right', type='kebab', ...props}) 
       <KebabMenuContent className='kebab-menu-content' side={side}>
         {links.map(link => {
           return (
-            <LinkClass to={link.to} href={link.to} key={link.label} onClick={link.onClick}>
+            <LinkClass to={link.to} href={link.to} key={link.label} onClick={link.onClick} state={link.state}>
               <KebabMenuItem>{link.label}</KebabMenuItem>
             </LinkClass>
           )


### PR DESCRIPTION
The state property can be used to set a stateful value for the new page, like passing extra value to the new page and accessing it from the useLocation() hook.

[sc-39380]